### PR TITLE
Mostrar la fecha correcta en la infobox del grafo

### DIFF
--- a/app/assets/javascripts/viz/network-graph.js
+++ b/app/assets/javascripts/viz/network-graph.js
@@ -548,7 +548,7 @@ function NetworkGraph(selector, infobox, undoBtn, redoBtn, historyParams) {
     if ( link.at !== null ) {
       infobox.append('span')
         .attr('class', 'separator')
-        .text('('+relation.at+')');
+        .text('('+link.at+')');
     } else if ( link.from !== null || link.to !== null ) {
       infobox.append('span')
         .attr('class', 'separator')


### PR DESCRIPTION
Utilizar la variable correcta cuando solo hay una fecha en la relación del gráfo Fixes #282